### PR TITLE
chore: replace slatify by notify-on-failure

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -164,7 +164,7 @@ jobs:
           sarif_file: "trivy-results.sarif"
 
       - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        uses: digitalservicebund/notify-on-failure-gha@0b21f14f28717b3b756282824976cdd1354b1235 # v1.3.0
         if: ${{ failure() }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -89,20 +89,10 @@ jobs:
           image_tag: typescript-vite-application-template:${{ github.sha }}
 
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65 # == v3.0.0
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() }}
         with:
-          type: ${{ job.status }}
-          job_name: "Build :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   audit-licenses:
     runs-on: ubuntu-latest
@@ -138,20 +128,10 @@ jobs:
         run: npm run audit:licences
 
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65 # == v3.0.0
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() }}
         with:
-          type: ${{ job.status }}
-          job_name: "License audit :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   vulnerability-scan:
     runs-on: ubuntu-latest
@@ -184,17 +164,7 @@ jobs:
           sarif_file: "trivy-results.sarif"
 
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65 # == v3.0.0
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() }}
         with:
-          type: ${{ job.status }}
-          job_name: "Vulnerability scan :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -37,17 +37,7 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65 # == v3.0.0
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() }}
         with:
-          type: ${{ job.status }}
-          job_name: "Vulnerability scan :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
       - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        uses: digitalservicebund/notify-on-failure-gha@0b21f14f28717b3b756282824976cdd1354b1235 # v1.3.0
         if: ${{ failure() }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -19,7 +19,7 @@ jobs:
         # enforced by digitalservicebund/github-actions/github-actions-linter
         uses: carhartl/talisman-secrets-scan-action@702fc5c52170632a568124896148a80f38521ac4
       - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        uses: digitalservicebund/notify-on-failure-gha@0b21f14f28717b3b756282824976cdd1354b1235 # v1.3.0
         if: ${{ failure() }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -19,17 +19,7 @@ jobs:
         # enforced by digitalservicebund/github-actions/github-actions-linter
         uses: carhartl/talisman-secrets-scan-action@702fc5c52170632a568124896148a80f38521ac4
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65 # == v3.0.0
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() }}
         with:
-          type: ${{ job.status }}
-          job_name: "Secrets scan :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Since [slatify](https://github.com/lazy-actions/slatify/) isn't maintained anymore, we're replacing it [notify-on-failure](https://github.com/digitalservicebund/notify-on-failure-gha).
All you have to do is review this PR, merge it, and let Platform know if you run into any issue.

More details [available here](https://platform-docs.prod.ds4g.net/user-docs/how-to-guides/ci-cd/slack-integration).
