### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -1,4 +1,6 @@
 name: Secrets Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/typescript-vite-application-template/security/code-scanning/11](https://github.com/digitalservicebund/typescript-vite-application-template/security/code-scanning/11)

To fix this issue, add a `permissions` block explicitly specifying the lowest required permissions at either the workflow root (applies to all jobs) or at the job level. In this case, setting `contents: read` at the workflow root is sufficient, considering the steps only check out code, scan for secrets, and send a Slack notification. This ensures the `GITHUB_TOKEN` has only read access to repository contents, adhering to the principle of least privilege and making the workflow more secure. Add the following block after the `name:` line and before the `on:` block in `.github/workflows/secrets-check.yml`:

```yaml
permissions:
  contents: read
```

No new imports or methods are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
